### PR TITLE
Define `%||%` for R <4.4

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,3 @@
 .onLoad <- function(lib, pkg) {
   run_on_load()
 }
-
-# Define %||% for R < 4.4
-if (!exists("%||%", envir = baseenv())) {
-  `%||%` <- function(x, y) if (is.null(x)) y else x
-}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,8 @@
 .onLoad <- function(lib, pkg) {
   run_on_load()
 }
+
+# Define %||% for R < 4.4
+if (!exists("%||%", envir = baseenv())) {
+  `%||%` <- function(x, y) if (is.null(x)) y else x
+}

--- a/vignettes/_helpers.R
+++ b/vignettes/_helpers.R
@@ -1,7 +1,7 @@
 library(plumber2)
 
-code_chunk <- function(output, language=""){
-  cat(paste0("```",language,"\n"))
+code_chunk <- function(output, language = "") {
+  cat(paste0("```", language, "\n"))
   output <- switch(
     language,
     json = jsonlite::prettify(output, indent = 2),
@@ -18,6 +18,11 @@ code_chunk <- function(output, language=""){
 
 #* Serialize an object into JSON the same way that plumber would.
 #* This way if the logic changes we consolidate all references to here.
-json_serialize <- function(obj){
+json_serialize <- function(obj) {
   jsonlite::toJSON(obj, auto_unbox = FALSE, pretty = TRUE)
+}
+
+# Define %||% for R < 4.4
+if (!exists("%||%", envir = baseenv())) {
+  `%||%` <- function(x, y) if (is.null(x)) y else x
 }

--- a/vignettes/_helpers.R
+++ b/vignettes/_helpers.R
@@ -1,7 +1,7 @@
 library(plumber2)
 
-code_chunk <- function(output, language = "") {
-  cat(paste0("```", language, "\n"))
+code_chunk <- function(output, language=""){
+  cat(paste0("```",language,"\n"))
   output <- switch(
     language,
     json = jsonlite::prettify(output, indent = 2),
@@ -18,11 +18,8 @@ code_chunk <- function(output, language = "") {
 
 #* Serialize an object into JSON the same way that plumber would.
 #* This way if the logic changes we consolidate all references to here.
-json_serialize <- function(obj) {
+json_serialize <- function(obj){
   jsonlite::toJSON(obj, auto_unbox = FALSE, pretty = TRUE)
 }
 
-# Define %||% for R < 4.4
-if (!exists("%||%", envir = baseenv())) {
-  `%||%` <- function(x, y) if (is.null(x)) y else x
-}
+`%||%` <- rlang::`%||%`


### PR DESCRIPTION
It seems one of the CI failure on older releases is due to `%||%`, which was introduced in R 4.4.

edit: As @eitsupi pointed out, in the package code, `%||%` is available thanks to `import(rlang)`, but vignettes is not the case.