### PR TITLE
Fix pass tags argument in `openapi_operation()`

### DIFF
--- a/R/spec_constructor.R
+++ b/R/spec_constructor.R
@@ -169,7 +169,8 @@ openapi_operation <- function(
     operation_id = operation_id,
     parameters = parameters,
     request_body = request_body,
-    responses = responses
+    responses = responses,
+    tags = tags
   ))
   if (length(op) != 0 && is.null(op$response)) {
     op$response <- list()


### PR DESCRIPTION
Otherwise `tags` argument is not passed downstream:

``` r
library(plumber2)

openapi_operation(
  summary = "My summary",
  description = "My desc",
  operation_id = "opid",
  tags = "ecommerce"
)
#> $summary
#> [1] "My summary"
#> 
#> $description
#> [1] "My desc"
#> 
#> $operation_id
#> [1] "opid"
#> 
#> $response
#> list()
```

<sup>Created on 2025-05-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

With the fix `tags` is in the output:

``` r
pkgload::load_all()
#> ℹ Loading plumber2

openapi_operation(
  summary = "My summary",
  description = "My desc",
  operation_id = "opid",
  tags = "ecommerce" 
)
#> $summary
#> [1] "My summary"
#> 
#> $description
#> [1] "My desc"
#> 
#> $operation_id
#> [1] "opid"
#> 
#> $tags
#> [1] "ecommerce"
#> 
#> $response
#> list()
```

<sup>Created on 2025-05-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
