### PR TITLE
`tags` argument is list in `openapi_operation()` rather than a character

### DIFF
--- a/R/spec_constructor.R
+++ b/R/spec_constructor.R
@@ -14,7 +14,7 @@
 #' are lists as constructed by `openapi_path()`
 #' @param tags For `openapi()` a list with elements corresponding to the value
 #' constructed by `openapi_tag()`. For `openapi_operation()` this argument is a
-#' simple character vector
+#' list, too.
 #'
 #' @return A list
 #'

--- a/R/spec_constructor.R
+++ b/R/spec_constructor.R
@@ -157,7 +157,7 @@ openapi_operation <- function(
   parameters = list(),
   request_body = openapi_request_body(),
   responses = list(),
-  tags = character()
+  tags = list()
 ) {
   if (!(is_list(responses) && is_named2(responses))) {
     cli::cli_abort("{.arg responses} must be a named list")

--- a/man/openapi.Rd
+++ b/man/openapi.Rd
@@ -57,7 +57,7 @@ openapi_operation(
   parameters = list(),
   request_body = openapi_request_body(),
   responses = list(),
-  tags = character()
+  tags = list()
 )
 
 openapi_parameter(
@@ -101,7 +101,7 @@ are lists as constructed by \code{openapi_path()}}
 
 \item{tags}{For \code{openapi()} a list with elements corresponding to the value
 constructed by \code{openapi_tag()}. For \code{openapi_operation()} this argument is a
-simple character vector}
+list, too.}
 
 \item{title}{A string giving the title of the API}
 


### PR DESCRIPTION
Can be seen with:

```
library(plumber2)

api_obj1 <-
  api(doc_type = "swagger", port = 8081) |>
  api_get(
    path = "sales",
    handler = identity,
    route = "ecommerce"
  ) |>
  api_doc_add(
    doc = openapi(
      info = openapi_info(
        title = "E-commerce API",
        version = "0.1.0",
      ),
      tags = list(
        openapi_tag(name = "ecommerce", description = "E-commerce data")
      ),
      paths = list(
        "sales" = openapi_path(
          "Conversion data",
          "Retrieve e-commerce conversion data",
          get = openapi_operation(
            tags = "ecommerce" # character makes path nesting badly rendered on swagger (one per character)
          )
        )
      )
    )
  )

api_run(api_obj1)

api_obj2 <-
  api(doc_type = "swagger", port = 8082) |>
  api_get(
    path = "sales",
    handler = identity,
    route = "ecommerce"
  ) |>
  api_doc_add(
    doc = openapi(
      info = openapi_info(
        title = "E-commerce API",
        version = "0.1.0",
      ),
      tags = list(
        openapi_tag(name = "ecommerce", description = "E-commerce data")
      ),
      paths = list(
        "sales" = openapi_path(
          "Conversion data",
          "Retrieve e-commerce conversion data",
          get = openapi_operation(
            tags = list("ecommerce") # list
          )
        )
      )
    )
  )

api_run(api_obj2)
```

What I mean by badly rendered:

<img width="891" alt="Screenshot 2025-05-20 at 14 40 22" src="https://github.com/user-attachments/assets/dbb06af1-e3b5-4fad-9abc-350af7894411" />
