### PR TITLE
bugfix avoid missing arguments

### DIFF
--- a/R/api_run.R
+++ b/R/api_run.R
@@ -48,8 +48,8 @@ api_run <- function(
   if (!is.null(host) || !is.null(port)) {
     old_host <- api$host
     old_port <- api$port
-    api$host <- host
-    api$port <- port
+    api$host <- ifelse(!is.null(host), host, old_host)
+    api$port <- ifelse(!is.null(port), port, old_port)
     on.exit(
       {
         api$host <- old_host


### PR DESCRIPTION
when the user only sets a value for port, e.g. `port = 8087L`, `host` is missing and a invalid address error occurs