### PR TITLE
document mcptools as a `_server.yml` adopter

### DIFF
--- a/vignettes/server_yml.qmd
+++ b/vignettes/server_yml.qmd
@@ -100,3 +100,4 @@ Below is a list with R webserver frameworks known to support the `_server.yml` s
 
 * [plumber2](https://plumber2.posit.co)
 * [fiery](https://fiery.data-imaginist.com)
+* [mcptools](https://posit-dev.github.io/mcptools/)


### PR DESCRIPTION
As of posit-dev/mcptools#106, mcptools uses the `_server.yml` standard.

Thanks for deliberately leaving this entry point open for other packages; made supporting mcptools on Connect much more straightforward.