### PR TITLE
Fix: Explicitly define `security` requirement for docs as per OpenAPI specification

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # plumber2 (development version)
 
+* Fix `@auth`/`add_auth()` not attaching the OpenAPI `security` requirement
+  to the endpoint, which meant docs UIs (RapiDoc, Swagger, Redoc) never send
+  the credential when trying out a protected endpoint. ([#90](https://github.com/posit-dev/plumber2/issues/90)).
+
 # plumber2 0.2.0
 
 * Fix a bug in constructing empty blocks for extending

--- a/R/Plumber2.R
+++ b/R/Plumber2.R
@@ -934,7 +934,7 @@ Plumber2 <- R6Class(
 
       if (add_doc) {
         self$add_api_doc(
-          fp$flow_to_openapi(flow, auth_scope),
+          list(security = fp$flow_to_openapi(flow, auth_scope)),
           subset = c("paths", as_openapi_path(path), method)
         )
       }


### PR DESCRIPTION
Fixes #90 

Currently, the way docs add the `security` requirement is as follows:

```r
self$add_api_doc(
  fp$flow_to_openapi(flow, auth_scope),
  subset = c("paths", as_openapi_path(path), method)
)
```

This fix proposes explicitly mentioning this so that doc providers pick it up.

```r
self$add_api_doc(
  list(security = fp$flow_to_openapi(flow, auth_scope)),
  subset = c("paths", as_openapi_path(path), method)
)
```

I've already tested this manually and it seems to solve the wall I was hitting in trying out `plumber2` for a while. 