### PR TITLE
Pass 'except' to firestorm::ReverseProxy ctor

### DIFF
--- a/R/Plumber2.R
+++ b/R/Plumber2.R
@@ -550,7 +550,8 @@ Plumber2 <- R6Class(
 
       shiny_proxy <- firestorm::ReverseProxy$new(
         paste0("http://127.0.0.1:", port),
-        path
+        path,
+        except
       )
       self$attach(shiny_proxy)
 


### PR DESCRIPTION
This PR fixes #93.